### PR TITLE
Composer update with 20 changes 2022-05-25

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1397,7 +1397,7 @@
         },
         {
             "name": "illuminate/broadcasting",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/broadcasting.git",
@@ -1454,7 +1454,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1507,16 +1507,16 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
-                "reference": "ca5c09f4ddf970e2e0b52bb340b4523d8f9bb4fd"
+                "reference": "dcf787ca2e026e838970b73857a3265c93fb80c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/cache/zipball/ca5c09f4ddf970e2e0b52bb340b4523d8f9bb4fd",
-                "reference": "ca5c09f4ddf970e2e0b52bb340b4523d8f9bb4fd",
+                "url": "https://api.github.com/repos/illuminate/cache/zipball/dcf787ca2e026e838970b73857a3265c93fb80c3",
+                "reference": "dcf787ca2e026e838970b73857a3265c93fb80c3",
                 "shasum": ""
             },
             "require": {
@@ -1563,20 +1563,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-04-14T18:35:06+00:00"
+            "time": "2022-05-23T15:54:33+00:00"
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "7d7617afdca6f15c881856c679da4e76820e7674"
+                "reference": "0a33aa68dfe98bcaa14b3b0b9eba355112c0a8d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/7d7617afdca6f15c881856c679da4e76820e7674",
-                "reference": "7d7617afdca6f15c881856c679da4e76820e7674",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/0a33aa68dfe98bcaa14b3b0b9eba355112c0a8d6",
+                "reference": "0a33aa68dfe98bcaa14b3b0b9eba355112c0a8d6",
                 "shasum": ""
             },
             "require": {
@@ -1618,11 +1618,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-16T15:20:45+00:00"
+            "time": "2022-05-19T14:29:30+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1668,7 +1668,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1716,7 +1716,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1776,7 +1776,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1827,7 +1827,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1875,16 +1875,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "ce164ad037e8f189a96aa14c00d04c3704767a2f"
+                "reference": "3c08b025b5f2f82a5b191375f8f26892a31e6bcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/ce164ad037e8f189a96aa14c00d04c3704767a2f",
-                "reference": "ce164ad037e8f189a96aa14c00d04c3704767a2f",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/3c08b025b5f2f82a5b191375f8f26892a31e6bcf",
+                "reference": "3c08b025b5f2f82a5b191375f8f26892a31e6bcf",
                 "shasum": ""
             },
             "require": {
@@ -1939,11 +1939,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-16T15:53:09+00:00"
+            "time": "2022-05-24T13:49:02+00:00"
         },
         {
             "name": "illuminate/events",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1998,7 +1998,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -2060,7 +2060,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2106,16 +2106,16 @@
         },
         {
             "name": "illuminate/mail",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/mail.git",
-                "reference": "b250c636f9f58dcc72d83bad5e42a9c1b7f32a82"
+                "reference": "83f3a404d02219afd7c40ef84d043d08320790f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/mail/zipball/b250c636f9f58dcc72d83bad5e42a9c1b7f32a82",
-                "reference": "b250c636f9f58dcc72d83bad5e42a9c1b7f32a82",
+                "url": "https://api.github.com/repos/illuminate/mail/zipball/83f3a404d02219afd7c40ef84d043d08320790f9",
+                "reference": "83f3a404d02219afd7c40ef84d043d08320790f9",
                 "shasum": ""
             },
             "require": {
@@ -2164,11 +2164,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-16T15:53:09+00:00"
+            "time": "2022-05-18T15:50:08+00:00"
         },
         {
             "name": "illuminate/notifications",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/notifications.git",
@@ -2226,7 +2226,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -2274,7 +2274,7 @@
         },
         {
             "name": "illuminate/queue",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
@@ -2339,16 +2339,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "70c24266d84fb3bb4ec58cf5229323afd2e3374e"
+                "reference": "d031324a8209335d10af8c90e5a467e503d417f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/70c24266d84fb3bb4ec58cf5229323afd2e3374e",
-                "reference": "70c24266d84fb3bb4ec58cf5229323afd2e3374e",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/d031324a8209335d10af8c90e5a467e503d417f1",
+                "reference": "d031324a8209335d10af8c90e5a467e503d417f1",
                 "shasum": ""
             },
             "require": {
@@ -2404,20 +2404,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-12T15:23:12+00:00"
+            "time": "2022-05-24T13:49:53+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
-                "reference": "487ea0ae2905c5988d4c70267f22cf3fe6ae9697"
+                "reference": "e050d72d314e16492ec08401b295a214adf2d7ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/testing/zipball/487ea0ae2905c5988d4c70267f22cf3fe6ae9697",
-                "reference": "487ea0ae2905c5988d4c70267f22cf3fe6ae9697",
+                "url": "https://api.github.com/repos/illuminate/testing/zipball/e050d72d314e16492ec08401b295a214adf2d7ee",
+                "reference": "e050d72d314e16492ec08401b295a214adf2d7ee",
                 "shasum": ""
             },
             "require": {
@@ -2462,11 +2462,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-15T15:55:52+00:00"
+            "time": "2022-05-24T14:00:57+00:00"
         },
         {
             "name": "illuminate/view",
-            "version": "v9.13.0",
+            "version": "v9.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",


### PR DESCRIPTION
  - Upgrading illuminate/broadcasting (v9.13.0 => v9.14.0)
  - Upgrading illuminate/bus (v9.13.0 => v9.14.0)
  - Upgrading illuminate/cache (v9.13.0 => v9.14.0)
  - Upgrading illuminate/collections (v9.13.0 => v9.14.0)
  - Upgrading illuminate/conditionable (v9.13.0 => v9.14.0)
  - Upgrading illuminate/config (v9.13.0 => v9.14.0)
  - Upgrading illuminate/console (v9.13.0 => v9.14.0)
  - Upgrading illuminate/container (v9.13.0 => v9.14.0)
  - Upgrading illuminate/contracts (v9.13.0 => v9.14.0)
  - Upgrading illuminate/database (v9.13.0 => v9.14.0)
  - Upgrading illuminate/events (v9.13.0 => v9.14.0)
  - Upgrading illuminate/filesystem (v9.13.0 => v9.14.0)
  - Upgrading illuminate/macroable (v9.13.0 => v9.14.0)
  - Upgrading illuminate/mail (v9.13.0 => v9.14.0)
  - Upgrading illuminate/notifications (v9.13.0 => v9.14.0)
  - Upgrading illuminate/pipeline (v9.13.0 => v9.14.0)
  - Upgrading illuminate/queue (v9.13.0 => v9.14.0)
  - Upgrading illuminate/support (v9.13.0 => v9.14.0)
  - Upgrading illuminate/testing (v9.13.0 => v9.14.0)
  - Upgrading illuminate/view (v9.13.0 => v9.14.0)
