### PR TITLE
Composer update with 22 changes 2022-05-26

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -905,16 +905,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.2",
+            "version": "7.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4"
+                "reference": "74a8602c6faec9ef74b7a9391ac82c5e65b1cdab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ac1ec1cd9b5624694c3a40be801d94137afb12b4",
-                "reference": "ac1ec1cd9b5624694c3a40be801d94137afb12b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/74a8602c6faec9ef74b7a9391ac82c5e65b1cdab",
+                "reference": "74a8602c6faec9ef74b7a9391ac82c5e65b1cdab",
                 "shasum": ""
             },
             "require": {
@@ -1009,7 +1009,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.3"
             },
             "funding": [
                 {
@@ -1025,7 +1025,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-20T14:16:28+00:00"
+            "time": "2022-05-25T13:24:33+00:00"
         },
         {
             "name": "guzzlehttp/guzzle-services",
@@ -1397,7 +1397,7 @@
         },
         {
             "name": "illuminate/broadcasting",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/broadcasting.git",
@@ -1454,7 +1454,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",
@@ -1507,7 +1507,7 @@
         },
         {
             "name": "illuminate/cache",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/cache.git",
@@ -1567,7 +1567,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1622,7 +1622,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -1668,7 +1668,7 @@
         },
         {
             "name": "illuminate/config",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
@@ -1716,7 +1716,7 @@
         },
         {
             "name": "illuminate/console",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/console.git",
@@ -1776,7 +1776,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
@@ -1827,7 +1827,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1875,16 +1875,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "3c08b025b5f2f82a5b191375f8f26892a31e6bcf"
+                "reference": "f797985bed955fab431cb45f2a65a9cfd7adc3bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/3c08b025b5f2f82a5b191375f8f26892a31e6bcf",
-                "reference": "3c08b025b5f2f82a5b191375f8f26892a31e6bcf",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/f797985bed955fab431cb45f2a65a9cfd7adc3bb",
+                "reference": "f797985bed955fab431cb45f2a65a9cfd7adc3bb",
                 "shasum": ""
             },
             "require": {
@@ -1939,11 +1939,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-24T13:49:02+00:00"
+            "time": "2022-05-25T14:27:13+00:00"
         },
         {
             "name": "illuminate/events",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -1998,7 +1998,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
@@ -2060,7 +2060,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -2106,7 +2106,7 @@
         },
         {
             "name": "illuminate/mail",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/mail.git",
@@ -2168,7 +2168,7 @@
         },
         {
             "name": "illuminate/notifications",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/notifications.git",
@@ -2226,7 +2226,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",
@@ -2274,16 +2274,16 @@
         },
         {
             "name": "illuminate/queue",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/queue.git",
-                "reference": "00509bc642ec036bebd2bba038183ee3607476b2"
+                "reference": "627376c7ca78c756eb890fbb50cbb0f21f6ce55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/queue/zipball/00509bc642ec036bebd2bba038183ee3607476b2",
-                "reference": "00509bc642ec036bebd2bba038183ee3607476b2",
+                "url": "https://api.github.com/repos/illuminate/queue/zipball/627376c7ca78c756eb890fbb50cbb0f21f6ce55d",
+                "reference": "627376c7ca78c756eb890fbb50cbb0f21f6ce55d",
                 "shasum": ""
             },
             "require": {
@@ -2335,20 +2335,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-15T20:07:24+00:00"
+            "time": "2022-05-25T14:26:24+00:00"
         },
         {
             "name": "illuminate/support",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "d031324a8209335d10af8c90e5a467e503d417f1"
+                "reference": "bf298be4236f77068daa249c483939d5d97321b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/d031324a8209335d10af8c90e5a467e503d417f1",
-                "reference": "d031324a8209335d10af8c90e5a467e503d417f1",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/bf298be4236f77068daa249c483939d5d97321b8",
+                "reference": "bf298be4236f77068daa249c483939d5d97321b8",
                 "shasum": ""
             },
             "require": {
@@ -2404,11 +2404,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-05-24T13:49:53+00:00"
+            "time": "2022-05-25T14:48:59+00:00"
         },
         {
             "name": "illuminate/testing",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/testing.git",
@@ -2466,7 +2466,7 @@
         },
         {
             "name": "illuminate/view",
-            "version": "v9.14.0",
+            "version": "v9.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/view.git",
@@ -3041,16 +3041,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.0.19",
+            "version": "3.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "670df21225d68d165a8df38587ac3f41caf608f8"
+                "reference": "42a2f47dcf39944e2aee1b660ee55ab6ef69b535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/670df21225d68d165a8df38587ac3f41caf608f8",
-                "reference": "670df21225d68d165a8df38587ac3f41caf608f8",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/42a2f47dcf39944e2aee1b660ee55ab6ef69b535",
+                "reference": "42a2f47dcf39944e2aee1b660ee55ab6ef69b535",
                 "shasum": ""
             },
             "require": {
@@ -3111,7 +3111,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.0.19"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.0.20"
             },
             "funding": [
                 {
@@ -3127,7 +3127,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-03T21:19:02+00:00"
+            "time": "2022-05-25T19:18:39+00:00"
         },
         {
             "name": "league/mime-type-detection",


### PR DESCRIPTION
  - Upgrading guzzlehttp/guzzle (7.4.2 => 7.4.3)
  - Upgrading illuminate/broadcasting (v9.14.0 => v9.14.1)
  - Upgrading illuminate/bus (v9.14.0 => v9.14.1)
  - Upgrading illuminate/cache (v9.14.0 => v9.14.1)
  - Upgrading illuminate/collections (v9.14.0 => v9.14.1)
  - Upgrading illuminate/conditionable (v9.14.0 => v9.14.1)
  - Upgrading illuminate/config (v9.14.0 => v9.14.1)
  - Upgrading illuminate/console (v9.14.0 => v9.14.1)
  - Upgrading illuminate/container (v9.14.0 => v9.14.1)
  - Upgrading illuminate/contracts (v9.14.0 => v9.14.1)
  - Upgrading illuminate/database (v9.14.0 => v9.14.1)
  - Upgrading illuminate/events (v9.14.0 => v9.14.1)
  - Upgrading illuminate/filesystem (v9.14.0 => v9.14.1)
  - Upgrading illuminate/macroable (v9.14.0 => v9.14.1)
  - Upgrading illuminate/mail (v9.14.0 => v9.14.1)
  - Upgrading illuminate/notifications (v9.14.0 => v9.14.1)
  - Upgrading illuminate/pipeline (v9.14.0 => v9.14.1)
  - Upgrading illuminate/queue (v9.14.0 => v9.14.1)
  - Upgrading illuminate/support (v9.14.0 => v9.14.1)
  - Upgrading illuminate/testing (v9.14.0 => v9.14.1)
  - Upgrading illuminate/view (v9.14.0 => v9.14.1)
  - Upgrading league/flysystem (3.0.19 => 3.0.20)
